### PR TITLE
Add more apps to risky list

### DIFF
--- a/common/src/main/java/icu/nullptr/hidemyapplist/common/app_presets/RootAppsPreset.kt
+++ b/common/src/main/java/icu/nullptr/hidemyapplist/common/app_presets/RootAppsPreset.kt
@@ -163,7 +163,14 @@ class RootAppsPreset : BasePreset(NAME) {
         }
 
         ZipFile(appInfo.sourceDir).use { zipFile ->
+            val manifestStr = AppPresets.instance.readManifest(packageName, zipFile)
+
             if (findAppsFromLibs(zipFile, libNames) || findAppsFromAssets(zipFile, assetNames)) {
+                return true
+            }
+
+            // Many older root apps add this permission
+            if (Utils.containsMultiple(manifestStr, ACCESS_SUPERUSER)) {
                 return true
             }
         }

--- a/common/src/main/java/icu/nullptr/hidemyapplist/common/app_presets/RootAppsPreset.kt
+++ b/common/src/main/java/icu/nullptr/hidemyapplist/common/app_presets/RootAppsPreset.kt
@@ -7,6 +7,7 @@ import java.util.zip.ZipFile
 class RootAppsPreset : BasePreset(NAME) {
     companion object {
         const val NAME = "root_apps"
+        const val ACCESS_SUPERUSER_PERM = "\u0000a\u0000n\u0000d\u0000r\u0000o\u0000i\u0000d\u0000.\u0000p\u0000e\u0000r\u0000m\u0000i\u0000s\u0000s\u0000i\u0000o\u0000n\u0000.\u0000A\u0000C\u0000C\u0000E\u0000S\u0000S\u0000_\u0000S\u0000U\u0000P\u0000E\u0000R\u0000U\u0000S\u0000E\u0000R"
     }
 
     override val exactPackageNames = setOf(
@@ -170,7 +171,7 @@ class RootAppsPreset : BasePreset(NAME) {
             }
 
             // Many older root apps add this permission
-            if (Utils.containsMultiple(manifestStr, ACCESS_SUPERUSER)) {
+            if (Utils.containsMultiple(manifestStr, ACCESS_SUPERUSER_PERM)) {
                 return true
             }
         }

--- a/common/src/main/java/icu/nullptr/hidemyapplist/common/app_presets/RootAppsPreset.kt
+++ b/common/src/main/java/icu/nullptr/hidemyapplist/common/app_presets/RootAppsPreset.kt
@@ -31,6 +31,7 @@ class RootAppsPreset : BasePreset(NAME) {
         "com.machiav3lli.backup",
         "com.bartixxx.opflashcontrol",
         "dev.ukanth.ufirewall",
+        "dev.ukanth.ufirewall.donate",
         "org.nuntius35.wrongpinshutdown",
         "ru.nsu.bobrofon.easysshfs",
         "x1125io.initdlight",
@@ -45,6 +46,9 @@ class RootAppsPreset : BasePreset(NAME) {
         "com.slash.batterychargelimit",
         "com.valhalla.thor",
         "me.itejo443.bindhosts",
+        "com.pittvandewitt.viperfx",
+        "com.aam.viper4android",
+        "james.dsp",
 
         // Scene's "Core Edition" cannot be detected in the Xposed preset
         "com.omarea.vtools",
@@ -55,15 +59,49 @@ class RootAppsPreset : BasePreset(NAME) {
         "com.lybxlpsv.kernelmanager",
         "com.html6405.boefflakernelconfig",
         "ccc71.st.cpu",
+        "com.umang96.radon",
+
+        // NetHunter related apps
+        "com.mayank.rucky",
+        "org.csploit.android",
+        "whid.usb.injector",
+        "de.tu_darmstadt.seemoo.nexmon",
+        "remote.hid.keyboard.client",
+        "com.softwarebakery.drivedroid",
+        "de.srlabs.snoopsnitch",
+        "com.hijacker",
+        "su.sniff.cepter",
+
+        // WPS WPA Tester
+        "com.tester.wpswpatester",
+
+        // LSpeed
+        "com.paget96.lsandroid",
+
+        // GMS Flags
+        "ua.polodarb.gmsflags",
+
+        // SysLog
+        "com.tortel.syslog",
+
+        // Stericson Busybox installer
+        "stericson.busybox",
+        "stericson.busybox.donate",
+
+        // Integrity Box
+        "meow.helper",
     )
 
     val libNames = arrayOf(
         "libkernelsu.so",
+        "libksud.so",
+        "libksu_susfs.so",
         "libapd.so",
         "libmagisk.so",
         "libmagiskboot.so",
         "libmmrl-kernelsu.so",
         "libzakoboot.so",
+        "libzakosign.so",
     )
 
     val assetNames = arrayOf(
@@ -73,6 +111,11 @@ class RootAppsPreset : BasePreset(NAME) {
 
     override fun canBeAddedIntoPreset(appInfo: ApplicationInfo): Boolean {
         val packageName = appInfo.packageName
+
+        // All NetHunter apps (Nethunter app, NH KeX, ...)
+        if (Utils.startsWith(packageName, "com.offsec.nethunter.")) {
+            return true
+        }
 
         // All libxzr apps (konabess, hkf, ...)
         if (Utils.startsWithMultiple(packageName, "xzr.", "moe.xzr.")) {

--- a/common/src/main/java/icu/nullptr/hidemyapplist/common/app_presets/RootAppsPreset.kt
+++ b/common/src/main/java/icu/nullptr/hidemyapplist/common/app_presets/RootAppsPreset.kt
@@ -95,14 +95,11 @@ class RootAppsPreset : BasePreset(NAME) {
 
     val libNames = arrayOf(
         "libkernelsu.so",
-        "libksud.so",
-        "libksu_susfs.so",
         "libapd.so",
         "libmagisk.so",
         "libmagiskboot.so",
         "libmmrl-kernelsu.so",
         "libzakoboot.so",
-        "libzakosign.so",
     )
 
     val assetNames = arrayOf(

--- a/common/src/main/java/icu/nullptr/hidemyapplist/common/app_presets/SuspiciousAppsPreset.kt
+++ b/common/src/main/java/icu/nullptr/hidemyapplist/common/app_presets/SuspiciousAppsPreset.kt
@@ -23,6 +23,7 @@ class SuspiciousAppsPreset : BasePreset(NAME) {
         "com.happymod.apk",
         "com.pd.pdhelper",
         "cm.aptoide.pt",
+        "com.offsec.nethunter.store",
 
         // File managers
         "com.speedsoftware.rootexplorer",
@@ -30,6 +31,29 @@ class SuspiciousAppsPreset : BasePreset(NAME) {
         "com.lonelycatgames.Xplore",
         "org.fossify.filemanager",
         "com.amaze.filemanager",
+
+        // auto clicker/macro apps
+        "com.truedevelopersstudio.automatictap.autoclicker"
+
+        // Traffic sniffers
+        "com.emanuelef.remote_capture",
+        "com.pcapdroid.mitm",
+
+        // lower level settings editor
+        "io.github.muntashirakon.setedit",
+
+        // App Manager
+        "io.github.muntashirakon.AppManager",
+
+        // NetHunter apps
+        "com.offsec.nhterm",
+        "com.offsec.nhvnc",
+
+        // NetHunter related apps
+        "org.exobel.routerkeygen",
+
+        // Gravitybox Unlocker
+        "com.ceco.gravitybox.unlocker",
     )
 
     /*

--- a/common/src/main/java/icu/nullptr/hidemyapplist/common/app_presets/SuspiciousAppsPreset.kt
+++ b/common/src/main/java/icu/nullptr/hidemyapplist/common/app_presets/SuspiciousAppsPreset.kt
@@ -49,9 +49,6 @@ class SuspiciousAppsPreset : BasePreset(NAME) {
         "com.offsec.nhterm",
         "com.offsec.nhvnc",
 
-        // NetHunter related apps
-        "org.exobel.routerkeygen",
-
         // Gravitybox Unlocker
         "com.ceco.gravitybox.unlocker",
     )


### PR DESCRIPTION
Add more apps to sus list:

- Added more apps to suspicious and root apps list
- Any apps with `ACCESS_SUPERUSER` permission will be added to rooted app list. Despite only old root apps use it, it can be an obvious detection point.
- Gravitybox Unlocker added as suspicious app due to its main app uses Xposed although i am not sure where i should put it on.