### PR TITLE
OneUI fixes and other improvements

### DIFF
--- a/common/src/main/java/icu/nullptr/hidemyapplist/common/RiskyPackageUtils.kt
+++ b/common/src/main/java/icu/nullptr/hidemyapplist/common/RiskyPackageUtils.kt
@@ -1,7 +1,7 @@
 package icu.nullptr.hidemyapplist.common
 
 import android.content.pm.ApplicationInfo
-import java.util.zip.ZipFile
+import icu.nullptr.hidemyapplist.common.Utils.checkSplitPackages
 
 object RiskyPackageUtils {
     private const val GMS_PROP = "\u0000c\u0000o\u0000m\u0000.\u0000g\u0000o\u0000o\u0000g\u0000l\u0000e\u0000.\u0000a\u0000n\u0000d\u0000r\u0000o\u0000i\u0000d\u0000.\u0000g\u0000m\u0000s\u0000."
@@ -11,20 +11,21 @@ object RiskyPackageUtils {
 
     fun appHasGMSConnection(query: String) = query in ignoredForRiskyPackagesList
 
-    internal fun tryToAddIntoGMSConnectionList(appInfo: ApplicationInfo, packageName: String, loggerFunction: ((String) -> Unit)?) {
-        if (packageName in ignoredForRiskyPackagesList) return
+    internal fun tryToAddIntoGMSConnectionList(appInfo: ApplicationInfo, packageName: String, loggerFunction: ((String) -> Unit)?): Boolean {
+        if (packageName in ignoredForRiskyPackagesList) return false
 
-        try {
-            ZipFile(appInfo.sourceDir).use { zipFile ->
-                val manifestStr = AppPresets.instance.readManifest(appInfo.sourceDir, zipFile)
+        return checkSplitPackages(appInfo) { key, zipFile ->
+            val manifestStr = AppPresets.instance.readManifest(key, zipFile)
 
-                // Checking with binary because the Android system sucks
-                if (manifestStr.contains(GMS_PROP) || manifestStr.contains(FIREBASE_PROP)) {
-                    if (ignoredForRiskyPackagesList.add(packageName)) {
-                        loggerFunction?.invoke("@appHasGMSConnection $packageName added in ignored packages list")
-                    }
+            // Checking with binary because the Android system sucks
+            if (manifestStr.contains(GMS_PROP) || manifestStr.contains(FIREBASE_PROP)) {
+                if (ignoredForRiskyPackagesList.add(packageName)) {
+                    loggerFunction?.invoke("@appHasGMSConnection $packageName added in ignored packages list")
+                    return@checkSplitPackages true
                 }
             }
-        } catch (_: Throwable) { }
+
+            return@checkSplitPackages false
+        }
     }
 }

--- a/common/src/main/java/icu/nullptr/hidemyapplist/common/RiskyPackageUtils.kt
+++ b/common/src/main/java/icu/nullptr/hidemyapplist/common/RiskyPackageUtils.kt
@@ -16,7 +16,7 @@ object RiskyPackageUtils {
 
         try {
             ZipFile(appInfo.sourceDir).use { zipFile ->
-                val manifestStr = AppPresets.instance.readManifest(packageName, zipFile)
+                val manifestStr = AppPresets.instance.readManifest(appInfo.sourceDir, zipFile)
 
                 // Checking with binary because the Android system sucks
                 if (manifestStr.contains(GMS_PROP) || manifestStr.contains(FIREBASE_PROP)) {

--- a/common/src/main/java/icu/nullptr/hidemyapplist/common/Utils.kt
+++ b/common/src/main/java/icu/nullptr/hidemyapplist/common/Utils.kt
@@ -6,6 +6,7 @@ import android.content.pm.PackageInfo
 import android.content.pm.ResolveInfo
 import android.os.Binder
 import android.os.Build
+import java.lang.reflect.Field
 import java.util.Random
 import java.util.zip.ZipFile
 
@@ -106,6 +107,17 @@ object Utils {
                 }
             }
 
+            return false
+        }
+    }
+
+    fun isSamsung(): Boolean {
+        try {
+            val semPlatformIntField: Field =
+                Build.VERSION::class.java.getDeclaredField("SEM_PLATFORM_INT")
+            semPlatformIntField.isAccessible = true
+            return semPlatformIntField.getInt(null) >= 0
+        } catch (_: Throwable) {
             return false
         }
     }

--- a/common/src/main/java/icu/nullptr/hidemyapplist/common/Utils.kt
+++ b/common/src/main/java/icu/nullptr/hidemyapplist/common/Utils.kt
@@ -7,6 +7,7 @@ import android.content.pm.ResolveInfo
 import android.os.Binder
 import android.os.Build
 import java.util.Random
+import java.util.zip.ZipFile
 
 object Utils {
 
@@ -91,5 +92,21 @@ object Utils {
             resolveInfo.activityInfo?.packageName ?:
             resolveInfo.serviceInfo?.packageName ?:
             resolveInfo.providerInfo!!.packageName
+    }
+
+    fun checkSplitPackages(appInfo: ApplicationInfo, onZipFile: (String, ZipFile) -> Boolean): Boolean {
+        val allLocations = setOf(appInfo.sourceDir, appInfo.publicSourceDir) /*+
+                (appInfo.splitSourceDirs ?: arrayOf()) +
+                (appInfo.splitPublicSourceDirs ?: arrayOf())*/
+
+        return allLocations.any { filePath ->
+            ZipFile(filePath).use { zipFile ->
+                if (onZipFile(filePath, zipFile)) {
+                    return true
+                }
+            }
+
+            return false
+        }
     }
 }

--- a/common/src/main/java/icu/nullptr/hidemyapplist/common/app_presets/BasePreset.kt
+++ b/common/src/main/java/icu/nullptr/hidemyapplist/common/app_presets/BasePreset.kt
@@ -54,22 +54,6 @@ abstract class BasePreset(val name: String) {
         return false
     }
 
-    fun checkSplitPackages(appInfo: ApplicationInfo, onZipFile: (String, ZipFile) -> Boolean): Boolean {
-        val allLocations = setOf(appInfo.sourceDir, appInfo.publicSourceDir) /*+
-                (appInfo.splitSourceDirs ?: arrayOf()) +
-                (appInfo.splitPublicSourceDirs ?: arrayOf())*/
-
-        return allLocations.any { filePath ->
-            ZipFile(filePath).use { zipFile ->
-                if (onZipFile(filePath, zipFile)) {
-                    return true
-                }
-            }
-
-            return false
-        }
-    }
-
     override fun toString() = "${javaClass.simpleName} {" +
             " \"exactPackageNames\": $exactPackageNames," +
             " \"packageNames\": $packageNames" +

--- a/common/src/main/java/icu/nullptr/hidemyapplist/common/app_presets/BasePreset.kt
+++ b/common/src/main/java/icu/nullptr/hidemyapplist/common/app_presets/BasePreset.kt
@@ -55,9 +55,9 @@ abstract class BasePreset(val name: String) {
     }
 
     fun checkSplitPackages(appInfo: ApplicationInfo, onZipFile: (String, ZipFile) -> Boolean): Boolean {
-        val allLocations = setOf(appInfo.sourceDir, appInfo.publicSourceDir) +
+        val allLocations = setOf(appInfo.sourceDir, appInfo.publicSourceDir) /*+
                 (appInfo.splitSourceDirs ?: arrayOf()) +
-                (appInfo.splitPublicSourceDirs ?: arrayOf())
+                (appInfo.splitPublicSourceDirs ?: arrayOf())*/
 
         return allLocations.any { filePath ->
             ZipFile(filePath).use { zipFile ->

--- a/common/src/main/java/icu/nullptr/hidemyapplist/common/app_presets/DetectorAppsPreset.kt
+++ b/common/src/main/java/icu/nullptr/hidemyapplist/common/app_presets/DetectorAppsPreset.kt
@@ -34,6 +34,7 @@ class DetectorAppsPreset  : BasePreset(NAME) {
         "com.atominvention.rootchecker",
         "com.joeykrim.rootcheck",
         "com.studio.duckdetector",
+        "com.chuqniudetector",
 
         // Add more detector apps (thanks @Yurii0307)
         "com.lingqing.detector",

--- a/common/src/main/java/icu/nullptr/hidemyapplist/common/app_presets/RootAppsPreset.kt
+++ b/common/src/main/java/icu/nullptr/hidemyapplist/common/app_presets/RootAppsPreset.kt
@@ -3,6 +3,7 @@ package icu.nullptr.hidemyapplist.common.app_presets
 import android.content.pm.ApplicationInfo
 import icu.nullptr.hidemyapplist.common.AppPresets
 import icu.nullptr.hidemyapplist.common.Utils
+import icu.nullptr.hidemyapplist.common.Utils.checkSplitPackages
 
 class RootAppsPreset(private val appPresets: AppPresets) : BasePreset(NAME) {
     companion object {

--- a/common/src/main/java/icu/nullptr/hidemyapplist/common/app_presets/SDhizukuAppsPreset.kt
+++ b/common/src/main/java/icu/nullptr/hidemyapplist/common/app_presets/SDhizukuAppsPreset.kt
@@ -3,6 +3,7 @@ package icu.nullptr.hidemyapplist.common.app_presets
 import android.content.pm.ApplicationInfo
 import icu.nullptr.hidemyapplist.common.AppPresets
 import icu.nullptr.hidemyapplist.common.Utils
+import icu.nullptr.hidemyapplist.common.Utils.checkSplitPackages
 
 class SDhizukuAppsPreset(private val appPresets: AppPresets) : BasePreset(NAME) {
     companion object {

--- a/common/src/main/java/icu/nullptr/hidemyapplist/common/app_presets/SuspiciousAppsPreset.kt
+++ b/common/src/main/java/icu/nullptr/hidemyapplist/common/app_presets/SuspiciousAppsPreset.kt
@@ -1,6 +1,7 @@
 package icu.nullptr.hidemyapplist.common.app_presets
 
 import android.content.pm.ApplicationInfo
+import icu.nullptr.hidemyapplist.common.Utils.checkSplitPackages
 
 class SuspiciousAppsPreset : BasePreset(NAME) {
     companion object {
@@ -113,12 +114,9 @@ class SuspiciousAppsPreset : BasePreset(NAME) {
         }
 
         return checkSplitPackages(appInfo) { _, zipFile ->
-            if (/*findAppsFromLibs(zipFile, libNames) ||*/ findAppsFromAssets(zipFile, assetNames)) {
-                return@checkSplitPackages true
-            }
+            return@checkSplitPackages /*findAppsFromLibs(zipFile, libNames) ||*/ findAppsFromAssets(zipFile, assetNames)
 
             // TODO: Add more suspicious apps
-            return@checkSplitPackages false
         }
     }
 }

--- a/common/src/main/java/icu/nullptr/hidemyapplist/common/app_presets/XposedModulesPreset.kt
+++ b/common/src/main/java/icu/nullptr/hidemyapplist/common/app_presets/XposedModulesPreset.kt
@@ -11,16 +11,18 @@ class XposedModulesPreset : BasePreset(NAME) {
     override val exactPackageNames = setOf<String>()
 
     override fun canBeAddedIntoPreset(appInfo: ApplicationInfo): Boolean {
-        ZipFile(appInfo.sourceDir).use { zipFile ->
+        checkSplitPackages(appInfo) { _, zipFile ->
             // Legacy Xposed method
             if (zipFile.getEntry("assets/xposed_init") != null) {
-                return true
+                return@checkSplitPackages true
             }
 
             // New LSPosed method
             if (zipFile.getEntry("META-INF/xposed/module.prop") != null) {
-                return true
+                return@checkSplitPackages true
             }
+
+            return@checkSplitPackages false
         }
 
         return false

--- a/common/src/main/java/icu/nullptr/hidemyapplist/common/app_presets/XposedModulesPreset.kt
+++ b/common/src/main/java/icu/nullptr/hidemyapplist/common/app_presets/XposedModulesPreset.kt
@@ -1,7 +1,7 @@
 package icu.nullptr.hidemyapplist.common.app_presets
 
 import android.content.pm.ApplicationInfo
-import java.util.zip.ZipFile
+import icu.nullptr.hidemyapplist.common.Utils.checkSplitPackages
 
 class XposedModulesPreset : BasePreset(NAME) {
     companion object {
@@ -11,7 +11,7 @@ class XposedModulesPreset : BasePreset(NAME) {
     override val exactPackageNames = setOf<String>()
 
     override fun canBeAddedIntoPreset(appInfo: ApplicationInfo): Boolean {
-        checkSplitPackages(appInfo) { _, zipFile ->
+        return checkSplitPackages(appInfo) { _, zipFile ->
             // Legacy Xposed method
             if (zipFile.getEntry("assets/xposed_init") != null) {
                 return@checkSplitPackages true
@@ -24,7 +24,5 @@ class XposedModulesPreset : BasePreset(NAME) {
 
             return@checkSplitPackages false
         }
-
-        return false
     }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -4,9 +4,9 @@ pluginManagement {
     repositories {
         gradlePluginPortal()
         google()
+        mavenCentral()
         maven("https://mirrors.cloud.tencent.com/nexus/repository/maven-public")
         maven("https://maven.aliyun.com/repository/public")
-        mavenCentral()
     }
 }
 
@@ -14,9 +14,9 @@ dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {
         google()
+        mavenCentral()
         maven("https://mirrors.cloud.tencent.com/nexus/repository/maven-public")
         maven("https://maven.aliyun.com/repository/public")
-        mavenCentral()
         maven("https://jitpack.io")
         maven("https://api.xposed.info/")
     }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -4,6 +4,8 @@ pluginManagement {
     repositories {
         gradlePluginPortal()
         google()
+        maven("https://mirrors.cloud.tencent.com/nexus/repository/maven-public")
+        maven("https://maven.aliyun.com/repository/public")
         mavenCentral()
     }
 }
@@ -12,6 +14,8 @@ dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {
         google()
+        maven("https://mirrors.cloud.tencent.com/nexus/repository/maven-public")
+        maven("https://maven.aliyun.com/repository/public")
         mavenCentral()
         maven("https://jitpack.io")
         maven("https://api.xposed.info/")

--- a/xposed/src/main/java/icu/nullptr/hidemyapplist/xposed/HMAService.kt
+++ b/xposed/src/main/java/icu/nullptr/hidemyapplist/xposed/HMAService.kt
@@ -36,7 +36,6 @@ import rikka.hidden.compat.ActivityManagerApis
 import java.io.File
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
-import kotlin.concurrent.thread
 
 class HMAService(val pms: IPackageManager, val pmn: Any?) : IHMAService.Stub() {
 

--- a/xposed/src/main/java/icu/nullptr/hidemyapplist/xposed/HMAService.kt
+++ b/xposed/src/main/java/icu/nullptr/hidemyapplist/xposed/HMAService.kt
@@ -84,11 +84,8 @@ class HMAService(val pms: IPackageManager, val pmn: Any?) : IHMAService.Stub() {
             logWithLevel(level, "AppPresets", msg)
         }
 
-        // Add thread to speed up the boot process
-        thread {
-            AppPresets.instance.reloadPresets(pms)
-            logI(TAG, "All presets are loaded")
-        }
+        AppPresets.instance.reloadPresets(pms)
+        logI(TAG, "All presets are loaded")
     }
 
     private fun searchDataDir() {

--- a/xposed/src/main/java/icu/nullptr/hidemyapplist/xposed/hook/ActivityHook.kt
+++ b/xposed/src/main/java/icu/nullptr/hidemyapplist/xposed/hook/ActivityHook.kt
@@ -99,13 +99,17 @@ class ActivityHook(private val service: HMAService) : IFrameworkHook {
             logD(TAG, "Loaded ${it.hookedMethod.name} hook from ${it.hookedMethod.declaringClass}!")
         }
 
-        /*
-        try {
-            (findMethodOrNull(COMPUTER_ENGINE_CLASS) {
+        if (!Utils.isSamsung()) {
+            hooks += findMethod(
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                    COMPUTER_ENGINE_CLASS
+                } else {
+                    PACKAGE_MANAGER_SERVICE_CLASS
+                },
+                findSuper = Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU,
+            ) {
                 name == "applyPostResolutionFilter"
-            } ?: findMethodOrNull(PACKAGE_MANAGER_SERVICE_CLASS, findSuper = true) {
-                name == "applyPostResolutionFilter"
-            })?.hookBefore { param ->
+            }.hookBefore { param ->
                 @Suppress("UNCHECKED_CAST") // I know what I do
                 val list = param.args.first() as List<ResolveInfo>?
                 if (list.isNullOrEmpty()) return@hookBefore
@@ -137,13 +141,8 @@ class ActivityHook(private val service: HMAService) : IFrameworkHook {
                         service.filterCount++
                     }
                 }
-            }?.let {
-                hooks += it
             }
-        } catch (e: Throwable) {
-            logE(TAG, e.toString(), e)
         }
-         */
     }
 
     override fun unload() {

--- a/xposed/src/main/java/icu/nullptr/hidemyapplist/xposed/hook/ActivityHook.kt
+++ b/xposed/src/main/java/icu/nullptr/hidemyapplist/xposed/hook/ActivityHook.kt
@@ -99,10 +99,11 @@ class ActivityHook(private val service: HMAService) : IFrameworkHook {
             logD(TAG, "Loaded ${it.hookedMethod.name} hook from ${it.hookedMethod.declaringClass}!")
         }
 
+        /*
         try {
             (findMethodOrNull(COMPUTER_ENGINE_CLASS) {
                 name == "applyPostResolutionFilter"
-            } ?: findMethodOrNull(PACKAGE_MANAGER_SERVICE_CLASS) {
+            } ?: findMethodOrNull(PACKAGE_MANAGER_SERVICE_CLASS, findSuper = true) {
                 name == "applyPostResolutionFilter"
             })?.hookBefore { param ->
                 @Suppress("UNCHECKED_CAST") // I know what I do
@@ -142,6 +143,7 @@ class ActivityHook(private val service: HMAService) : IFrameworkHook {
         } catch (e: Throwable) {
             logE(TAG, e.toString(), e)
         }
+         */
     }
 
     override fun unload() {


### PR DESCRIPTION
- Remove split APK checks for preset lists, it will reduce boot time a lot (also remove thread for loading the preset lists)
- Remove applyPostResolutionFilter hook for Samsung stock ROM
- Improve several preset loaders
- Add new apps into preset lists
- Other fixes and improvements