### PR TITLE
feat: remove animations when it's disabled in system settings

### DIFF
--- a/app/src/main/java/icu/nullptr/hidemyapplist/ui/util/AccessibilityUtils.kt
+++ b/app/src/main/java/icu/nullptr/hidemyapplist/ui/util/AccessibilityUtils.kt
@@ -1,0 +1,14 @@
+package icu.nullptr.hidemyapplist.ui.util
+
+import android.content.ContentResolver
+import android.provider.Settings
+
+class AccessibilityUtils {
+    companion object {
+        fun isAnimationEnabled(cr: ContentResolver): Boolean {
+            return !(Settings.Global.getFloat(cr, Settings.Global.ANIMATOR_DURATION_SCALE, 1.0f) == 0.0f
+                && Settings.Global.getFloat(cr, Settings.Global.TRANSITION_ANIMATION_SCALE, 1.0f) == 0.0f
+                && Settings.Global.getFloat(cr, Settings.Global.WINDOW_ANIMATION_SCALE, 1.0f) == 0.0f)
+        }
+    }
+}

--- a/app/src/main/java/icu/nullptr/hidemyapplist/ui/util/Fragment.kt
+++ b/app/src/main/java/icu/nullptr/hidemyapplist/ui/util/Fragment.kt
@@ -33,7 +33,12 @@ private val navOptions by lazy {
 }
 
 fun Fragment.navigate(@IdRes resId: Int, args: Bundle? = null) {
-    navController.navigate(resId, args, navOptions)
+    val cr = requireContext().contentResolver
+    if (AccessibilityUtils.isAnimationEnabled(cr)) {
+        navController.navigate(resId, args, navOptions)
+    } else {
+        navController.navigate(resId, args)
+    }
 }
 
 fun Fragment.setupToolbar(

--- a/app/src/main/java/org/frknkrc44/hma_oss/ui/fragment/AboutFragment.kt
+++ b/app/src/main/java/org/frknkrc44/hma_oss/ui/fragment/AboutFragment.kt
@@ -16,6 +16,7 @@ import androidx.transition.TransitionManager
 import by.kirich1409.viewbindingdelegate.viewBinding
 import com.bumptech.glide.Glide
 import icu.nullptr.hidemyapplist.service.PrefManager
+import icu.nullptr.hidemyapplist.ui.util.AccessibilityUtils
 import icu.nullptr.hidemyapplist.ui.util.ThemeUtils.homeItemBackgroundColor
 import icu.nullptr.hidemyapplist.ui.util.navController
 import icu.nullptr.hidemyapplist.ui.util.setEdge2EdgeFlags
@@ -38,6 +39,12 @@ class AboutFragment : Fragment(R.layout.fragment_about) {
         }
 
         val tint = ColorStateList.valueOf(homeItemBackgroundColor())
+
+        if (!AccessibilityUtils.isAnimationEnabled(requireContext().contentResolver)) {
+            with(binding.aboutScroll) {
+                overScrollMode = View.OVER_SCROLL_NEVER
+            }
+        }
 
         with(binding.aboutHeader) {
             with(backButton.parent as View) {

--- a/app/src/main/res/layout/fragment_about.xml
+++ b/app/src/main/res/layout/fragment_about.xml
@@ -12,6 +12,7 @@
         layout="@layout/fragment_about_header" />
 
     <ScrollView
+        android:id="@+id/about_scroll"
         android:layout_marginTop="@dimen/item_padding_vertical"
         android:layout_width="match_parent"
         android:layout_height="match_parent">


### PR DESCRIPTION
This removes animations when it's disabled in system settings *Settings* -> `Accessibility` -> `Display` `Colour and Motion` -> `Experimental` `Remove animations` `Reduce movement on the screen`.

I would greatly appreciate if you could consider this. UI animations make me really frustrated and gives me a headache. Thanks in advance.