### PR TITLE
fix: compatible with Samsung

### DIFF
--- a/xposed/src/main/java/icu/nullptr/hidemyapplist/xposed/hook/PmsHookTargetBase.kt
+++ b/xposed/src/main/java/icu/nullptr/hidemyapplist/xposed/hook/PmsHookTargetBase.kt
@@ -131,8 +131,8 @@ abstract class PmsHookTargetBase(protected val service: HMAService) : IFramework
             hooks += findMethod(COMPUTER_ENGINE_CLASS) {
                 name == "getPackageInfoInternal"
             }.hookBefore { param ->
-                val targetApp = param.args.first() as String? ?: return@hookBefore
-                val callingUid = param.args[3] as Int
+                val targetApp = param.args.firstOrNull { it is String } as? String ?: return@hookBefore
+                val callingUid = Binder.getCallingUid()
                 if (callingUid == Constants.UID_SYSTEM) return@hookBefore
                 logV(TAG, "@${param.method.name} incoming query: $callingUid => $targetApp")
                 if (service.shouldHideFromUid(callingUid, targetApp) == true) {
@@ -154,8 +154,8 @@ abstract class PmsHookTargetBase(protected val service: HMAService) : IFramework
             hooks += findMethod(COMPUTER_ENGINE_CLASS) {
                 name == "getApplicationInfoInternal"
             }.hookBefore { param ->
-                val targetApp = param.args.first() as String? ?: return@hookBefore
-                val callingUid = param.args[2] as Int
+                val targetApp = param.args.firstOrNull { it is String } as? String ?: return@hookBefore
+                val callingUid = Binder.getCallingUid()
                 if (callingUid == Constants.UID_SYSTEM) return@hookBefore
                 logV(TAG, "@${param.method.name} incoming query: $callingUid => $targetApp")
                 if (service.shouldHideFromUid(callingUid, targetApp) == true) {

--- a/xposed/src/main/java/icu/nullptr/hidemyapplist/xposed/hook/PmsHookTargetBase.kt
+++ b/xposed/src/main/java/icu/nullptr/hidemyapplist/xposed/hook/PmsHookTargetBase.kt
@@ -132,7 +132,7 @@ abstract class PmsHookTargetBase(protected val service: HMAService) : IFramework
                 name == "getPackageInfoInternal"
             }.hookBefore { param ->
                 val targetApp = param.args.firstOrNull { it is String } as? String ?: return@hookBefore
-                val callingUid = Binder.getCallingUid()
+                val callingUid = param.args.firstOrNull { it is Int } as? Int ?: Binder.getCallingUid()
                 if (callingUid == Constants.UID_SYSTEM) return@hookBefore
                 logV(TAG, "@${param.method.name} incoming query: $callingUid => $targetApp")
                 if (service.shouldHideFromUid(callingUid, targetApp) == true) {
@@ -155,7 +155,7 @@ abstract class PmsHookTargetBase(protected val service: HMAService) : IFramework
                 name == "getApplicationInfoInternal"
             }.hookBefore { param ->
                 val targetApp = param.args.firstOrNull { it is String } as? String ?: return@hookBefore
-                val callingUid = Binder.getCallingUid()
+                val callingUid = param.args.firstOrNull { it is Int } as? Int ?: Binder.getCallingUid()
                 if (callingUid == Constants.UID_SYSTEM) return@hookBefore
                 logV(TAG, "@${param.method.name} incoming query: $callingUid => $targetApp")
                 if (service.shouldHideFromUid(callingUid, targetApp) == true) {


### PR DESCRIPTION
I got an error on my samsung(android 16): `EZXHelper: java.lang.ClassCastException: java.lang.Interger cannot be cast to java.lang.String`

the decompiled samsung services.jar com.android.server.pm.Computer.getPackageInfoInternal is:

```java
@Override
    public final PackageInfo getPackageInfoInternal(int v, int v1, String s, long v2, long v3) {
        if(this.mUserManager.mLocalService.exists(v1)) {
            long v4 = this.updateFlagsForPackage(v1, v3);
            this.enforceCrossUserPermission(Binder.getCallingUid(), false, "get package info", v1, false, false);
            String s1 = this.resolveInternalPackageName(v2, s);
            boolean z = false;
            int v5 = !SemDualAppManager.isDualAppId(v1) || !SemDualAppManager.isDualAppId(UserHandle.getUserId(Binder.getCallingUid())) || !DualAppManagerService.shouldForwardToOwner(s1) ? v1 : 0;
            boolean z1 = Long.compare(0x200000L & v4, 0L) != 0;
            if((0x40000000L & v4) != 0L) {
                z = true;
            }

            Settings settings0 = this.mSettings.mSettings;
            if(z1) {
                PackageSetting packageSetting0 = settings0.getDisabledSystemPkgLPr(s1);
                if(packageSetting0 != null) {
                    return !z && packageSetting0.getPkg() != null && packageSetting0.getPkg().isApex() || this.filterSharedLibPackage(packageSetting0, v, v5, v4) || this.shouldFilterApplication(packageSetting0, v, v5) ? null : this.generatePackageInfo(packageSetting0, v4, v5);
                }
            }

            AndroidPackage androidPackage0 = (AndroidPackage)this.mPackages.mStorage.get(s1);
            if(!z1 || androidPackage0 == null || settings0.getPackageLPr(s1).isSystem()) {
                if(androidPackage0 != null) {
                    PackageSetting packageSetting1 = this.getPackageStateInternal(androidPackage0.getPackageName());
                    return !z && androidPackage0.isApex() || this.filterSharedLibPackage(packageSetting1, v, v5, v4) || packageSetting1 != null && this.shouldFilterApplication(packageSetting1, v, v5) ? null : this.generatePackageInfo(packageSetting1, v4, v5);
                }

                if(!z1 && (0x100402000L & v4) != 0L) {
                    PackageSetting packageSetting2 = settings0.getPackageLPr(s1);
                    return packageSetting2 == null || this.filterSharedLibPackage(packageSetting2, v, v5, v4) || this.shouldFilterApplication(packageSetting2, v, v5) ? null : this.generatePackageInfo(packageSetting2, v4, v5);
                }
            }
        }

        return null;
    }
```

com.android.server.pm.Computer.getApplicationInfoInternal is:

```java
@Override
    public final ApplicationInfo getApplicationInfoInternal(int v, int v1, long v2, String s) {
        if(this.mUserManager.mLocalService.exists(v1)) {
            long v3 = this.updateFlagsForPackage(v1, v2);
            if(!this.isRecentsAccessingChildProfiles(Binder.getCallingUid(), v1)) {
                this.enforceCrossUserPermission(Binder.getCallingUid(), false, "get application info", v1, false, false);
            }

            String s1 = this.resolveInternalPackageName(-1L, s);
            AndroidPackage androidPackage0 = (AndroidPackage)this.mPackages.mStorage.get(s1);
            boolean z = Long.compare(0x40000000L & v3, 0L) != 0;
            if(androidPackage0 == null) {
                goto label_17;
            }

            PackageSetting packageSetting0 = this.mSettings.mSettings.getPackageLPr(s1);
            if(packageSetting0 != null) {
                if(SemDualAppManager.isDualAppId(v1) && SemDualAppManager.isDualAppId(UserHandle.getUserId(Binder.getCallingUid())) && DualAppManagerService.shouldForwardToOwner(s1)) {
                    v1 = 0;
                }

                if((z || !androidPackage0.isApex()) && !this.filterSharedLibPackage(packageSetting0, v, v1, v3) && !this.shouldFilterApplication(packageSetting0, v, v1)) {
                    ApplicationInfo applicationInfo0 = PackageInfoUtils.generateApplicationInfo(androidPackage0, v3, packageSetting0.getUserStateOrDefault(v1), v1, packageSetting0);
                    if(applicationInfo0 != null) {
                        applicationInfo0.packageName = ComputerEngine.resolveExternalPackageName(androidPackage0);
                    }

                    return applicationInfo0;
                label_17:
                    if(!"android".equals(s1) && !"system".equals(s1)) {
                        return (0x100402000L & v3) == 0L ? null : this.generateApplicationInfoFromSettings(v, v1, v3, s1);
                    }

                    return this.androidApplication();
                }
            }
        }

        return null;
    }
```

dynamically find the first `String` as `targetApp` and use `Binder.getCallingUid()` instead of `param.args[3] as Int`

It works on my samsung phone.

Gemini says it is right to replace `param.args[3] as Int`  with `Binder.getCallingUid()` , but I dont know Android Binder mechanism, so please review my code, thank you