### PR TITLE
improve enforce-ksu-kernel.sh prompt

### DIFF
--- a/zygote/src/main/assets/customize.d/21-enforce-ksu-kernel.sh
+++ b/zygote/src/main/assets/customize.d/21-enforce-ksu-kernel.sh
@@ -17,8 +17,8 @@ if [ "$KSU" ]; then
 
     # language pack
     if echo "$SYSTEM_LANG" | grep -q "zh"; then
-        KSU_VERSION_MISMATCH_WARN="! 警告: KernelSU 管理器 ($KSU_VER_CODE) 与驱动 ($KSU_KERNEL_VER_CODE) 版本不匹配! HMA-OSS 不对由此引发的系统异常负责，且模块可能无法激活!"
-        KSU_VERSION_MISMATCH_ERR="! 错误: KernelSU 管理器 ($KSU_VER_CODE) 与驱动 ($KSU_KERNEL_VER_CODE) 版本不匹配! 请升级LKM驱动版本以继续安装HMA-OSS"
+        KSU_VERSION_MISMATCH_WARN="! 警告: KernelSU 管理器版本 ($KSU_VER_CODE) 与驱动版本 ($KSU_KERNEL_VER_CODE) 不匹配! HMA-OSS 不对由此引发的系统异常负责，且模块可能无法激活!"
+        KSU_VERSION_MISMATCH_ERR="! 错误: KernelSU 管理器版本 ($KSU_VER_CODE) 与驱动版本 ($KSU_KERNEL_VER_CODE) 不匹配! 请升级LKM驱动版本以继续安装HMA-OSS"
         INSTALLER_CONTINUE_MSG(){
             echo "- 安装将在 $1 秒后继续"
         }

--- a/zygote/src/main/assets/customize.d/21-enforce-ksu-kernel.sh
+++ b/zygote/src/main/assets/customize.d/21-enforce-ksu-kernel.sh
@@ -8,16 +8,18 @@ if [ "$KSU" ]; then
     [ -z "$SYSTEM_LANG" ] && SYSTEM_LANG=$(getprop persist.sys.language 2>/dev/null)
     [ -z "$SYSTEM_LANG" ] && SYSTEM_LANG=$(settings get system system_locales 2>/dev/null)
 
+    KSU_VERSION_MISMATCH_WARN="! KernelSU manager version ($KSU_VER_CODE) does not match kernel version ($KSU_KERNEL_VER_CODE). HMA-OSS not take any responsibilities for incompatibilities!"
+    KSU_VERSION_MISMATCH_ERR="! KernelSU manager version ($KSU_VER_CODE) does not match kernel version ($KSU_KERNEL_VER_CODE). Aborting..."
+    INSTALLER_CONTINUE_MSG(){
+        echo "- The installer will continue in $1 seconds"
+    }
+
     # language pack
     if echo "$SYSTEM_LANG" | grep -q "zh"; then
-        KSU_VERSION_MISMATCH_WARN="! 警告: KernelSU 管理器 ($KSU_VER_CODE) 与内核 ($KSU_KERNEL_VER_CODE) 版本不匹配! HMA-OSS 不对由此引发的系统异常（如: 卡米）负责，且模块可能无法激活!"
+        KSU_VERSION_MISMATCH_WARN="! 警告: KernelSU 管理器 ($KSU_VER_CODE) 与驱动 ($KSU_KERNEL_VER_CODE) 版本不匹配! HMA-OSS 不对由此引发的系统异常负责，且模块可能无法激活!"
+        KSU_VERSION_MISMATCH_ERR="! 错误: KernelSU 管理器 ($KSU_VER_CODE) 与驱动 ($KSU_KERNEL_VER_CODE) 版本不匹配! 请升级LKM驱动版本以继续安装HMA-OSS"
         INSTALLER_CONTINUE_MSG(){
             echo "- 安装将在 $1 秒后继续"
-        }
-    else
-        KSU_VERSION_MISMATCH_WARN="! KernelSU manager version ($KSU_VER_CODE) does not match kernel version ($KSU_KERNEL_VER_CODE). HMA-OSS not take any responsibilities for incompatibilities!"
-        INSTALLER_CONTINUE_MSG(){
-            echo "- The installer will continue in $1 seconds"
         }
     fi
 
@@ -25,7 +27,7 @@ if [ "$KSU" ]; then
     if [ "$KSU_VER_CODE" != "$KSU_KERNEL_VER_CODE" ]; then
         if lsmod 2>/dev/null | grep -q kernelsu
         then
-            abort "$KSU_VERSION_MISMATCH_WARN"
+            abort "$KSU_VERSION_MISMATCH_ERR"
         else
             ui_print "$KSU_VERSION_MISMATCH_WARN"
             ui_print "$(INSTALLER_CONTINUE_MSG 5)"

--- a/zygote/src/main/assets/customize.d/21-enforce-ksu-kernel.sh
+++ b/zygote/src/main/assets/customize.d/21-enforce-ksu-kernel.sh
@@ -8,6 +8,7 @@ if [ "$KSU" ]; then
     [ -z "$SYSTEM_LANG" ] && SYSTEM_LANG=$(getprop persist.sys.language 2>/dev/null)
     [ -z "$SYSTEM_LANG" ] && SYSTEM_LANG=$(settings get system system_locales 2>/dev/null)
 
+    # default language
     KSU_VERSION_MISMATCH_WARN="! KernelSU manager version ($KSU_VER_CODE) does not match kernel version ($KSU_KERNEL_VER_CODE). HMA-OSS not take any responsibilities for incompatibilities!"
     KSU_VERSION_MISMATCH_ERR="! KernelSU manager version ($KSU_VER_CODE) does not match kernel version ($KSU_KERNEL_VER_CODE). Aborting..."
     INSTALLER_CONTINUE_MSG(){

--- a/zygote/src/main/assets/customize.d/21-enforce-ksu-kernel.sh
+++ b/zygote/src/main/assets/customize.d/21-enforce-ksu-kernel.sh
@@ -10,7 +10,7 @@ if [ "$KSU" ]; then
 
     # default language
     KSU_VERSION_MISMATCH_WARN="! KernelSU manager version ($KSU_VER_CODE) does not match kernel driver version ($KSU_KERNEL_VER_CODE). HMA-OSS will not take any responsibilities for incompatibilities!"
-    KSU_VERSION_MISMATCH_ERR="! KernelSU manager version ($KSU_VER_CODE) does not match kernel driver version ($KSU_KERNEL_VER_CODE). Aborting..."
+    KSU_VERSION_MISMATCH_ERR="! KernelSU manager version ($KSU_VER_CODE) does not match kernel driver version ($KSU_KERNEL_VER_CODE). Please upgrade the LKM driver version to continue installation, Aborting..."
     INSTALLER_CONTINUE_MSG(){
         echo "- The installer will continue in $1 seconds"
     }

--- a/zygote/src/main/assets/customize.d/21-enforce-ksu-kernel.sh
+++ b/zygote/src/main/assets/customize.d/21-enforce-ksu-kernel.sh
@@ -9,7 +9,7 @@ if [ "$KSU" ]; then
     [ -z "$SYSTEM_LANG" ] && SYSTEM_LANG=$(settings get system system_locales 2>/dev/null)
 
     # default language
-    KSU_VERSION_MISMATCH_WARN="! KernelSU manager version ($KSU_VER_CODE) does not match kernel version ($KSU_KERNEL_VER_CODE). HMA-OSS not take any responsibilities for incompatibilities!"
+    KSU_VERSION_MISMATCH_WARN="! KernelSU manager version ($KSU_VER_CODE) does not match kernel driver version ($KSU_KERNEL_VER_CODE). HMA-OSS will not take any responsibilities for incompatibilities!"
     KSU_VERSION_MISMATCH_ERR="! KernelSU manager version ($KSU_VER_CODE) does not match kernel version ($KSU_KERNEL_VER_CODE). Aborting..."
     INSTALLER_CONTINUE_MSG(){
         echo "- The installer will continue in $1 seconds"

--- a/zygote/src/main/assets/customize.d/21-enforce-ksu-kernel.sh
+++ b/zygote/src/main/assets/customize.d/21-enforce-ksu-kernel.sh
@@ -10,7 +10,7 @@ if [ "$KSU" ]; then
 
     # default language
     KSU_VERSION_MISMATCH_WARN="! KernelSU manager version ($KSU_VER_CODE) does not match kernel driver version ($KSU_KERNEL_VER_CODE). HMA-OSS will not take any responsibilities for incompatibilities!"
-    KSU_VERSION_MISMATCH_ERR="! KernelSU manager version ($KSU_VER_CODE) does not match kernel version ($KSU_KERNEL_VER_CODE). Aborting..."
+    KSU_VERSION_MISMATCH_ERR="! KernelSU manager version ($KSU_VER_CODE) does not match kernel driver version ($KSU_KERNEL_VER_CODE). Aborting..."
     INSTALLER_CONTINUE_MSG(){
         echo "- The installer will continue in $1 seconds"
     }


### PR DESCRIPTION
1. feat: add new prompt for "aborting lkm"
2. refactor: use english as default language and fallback, instead of "else" statement

Modification 2 is to prevent empty output caused by some language packs not implementing.