### PR TITLE
add: module working status in module.prop

### DIFF
--- a/zygote/src/main/assets/action.sh
+++ b/zygote/src/main/assets/action.sh
@@ -1,3 +1,12 @@
 #!/system/bin/sh
 
-am start org.frknkrc44.hma_oss/org.frknkrc44.hma_oss.ui.activity.MainActivity
+MODDIR="${0%/*}"
+
+# launch manager first
+echo "Launching HMA-OSS on user 0"
+am start -n org.frknkrc44.hma_oss/org.frknkrc44.hma_oss.ui.activity.MainActivity --user 0
+
+# reload module status
+# NOTE: `update_desc.sh` already replace whole description= line so i don't think re-copy is neccessary
+sh "$MODDIR/update_desc.sh"
+echo "Updated module status"

--- a/zygote/src/main/assets/action.sh
+++ b/zygote/src/main/assets/action.sh
@@ -1,3 +1,11 @@
 #!/system/bin/sh
 
+# NOTE: `service.sh` already replace whole description= line so i don't think re-copy is neccessary ~~i guess~~
+MODDIR=/data/adb/modules/hma_oss_zygisk
+
+# launch manager first
 am start org.frknkrc44.hma_oss/org.frknkrc44.hma_oss.ui.activity.MainActivity
+
+# reload module status
+sh "$MODDIR"/service.sh
+echo "Updated module status"

--- a/zygote/src/main/assets/action.sh
+++ b/zygote/src/main/assets/action.sh
@@ -1,12 +1,34 @@
 #!/system/bin/sh
 
 MODDIR="${0%/*}"
+PKG=org.frknkrc44.hma_oss
+ACTIVITY=org.frknkrc44.hma_oss.ui.activity.MainActivity
+APK_FILE="$MODDIR/manager.apk"
 
-# launch manager first
-echo "Launching HMA-OSS on user 0"
-am start -n org.frknkrc44.hma_oss/org.frknkrc44.hma_oss.ui.activity.MainActivity --user 0
-
-# reload module status
-# NOTE: `update_desc.sh` already replace whole description= line so i don't think re-copy is neccessary
+# reload module status first (regardless of launch outcome)
 sh "$MODDIR/update_desc.sh"
-echo "Updated module status"
+echo "- Updated module status"
+
+install_pkg() {
+  pm install --user $1 $APK_FILE 2>&1
+
+  [ $? -ne 0 ] && echo "! Cannot install the manager app for user "$1
+}
+
+launch_pkg() {
+  echo "- Launching HMA-OSS manager on user "$1
+  am start -n $PKG/$ACTIVITY --user $1
+}
+
+for user in $(pm list users | cut -f1 -d: | cut -f2 -d{ | tail -n +2)
+  do
+    # if path detected in user then install the manager app for it (except Xiaomi's dual app space)
+    if [ "$user" != "999" ] && pm path --user $user $PKG &> /dev/null
+    then
+      launch_pkg $user
+      exit 0
+    fi
+done
+
+echo "- Manager app not found, installing for user 0"
+install_pkg 0 && launch_pkg 0

--- a/zygote/src/main/assets/action.sh
+++ b/zygote/src/main/assets/action.sh
@@ -12,7 +12,7 @@ echo "- Updated module status"
 install_pkg() {
   pm install --user $1 $APK_FILE 2>&1
 
-  [ $? -ne 0 ] && echo "! Cannot install the manager app for user "$1
+  [ $? -ne 0 ] && echo "! Cannot install the manager app for user "$1 || true
 }
 
 launch_pkg() {

--- a/zygote/src/main/assets/customize.d/40-setup-module-status.sh
+++ b/zygote/src/main/assets/customize.d/40-setup-module-status.sh
@@ -1,0 +1,12 @@
+#!/system/bin/sh
+
+# ref: https://github.com/PerformanC/ReZygisk/blob/e42886f48eb1c9eabcc94f08a3c3af0cdbffb99e/module/src/customize.sh#L102-L114
+
+mkdir -p /data/adb/post-mount.d
+mkdir -p /data/adb/post-fs-data.d
+
+cp "$MODPATH"/hmaoss.sh /data/adb/post-fs-data.d/hmaoss.sh
+
+cp "/data/adb/post-fs-data.d/hmaoss.sh" "/data/adb/post-mount.d/hmaoss.sh"
+
+cp "$MODPATH/module.prop" "$MODPATH/module.prop.bak"

--- a/zygote/src/main/assets/customize.d/40-setup-module-status.sh
+++ b/zygote/src/main/assets/customize.d/40-setup-module-status.sh
@@ -1,0 +1,13 @@
+#!/system/bin/sh
+
+# this script contain code from ReZygisk
+# original code: https://github.com/PerformanC/ReZygisk/blob/e42886f48eb1c9eabcc94f08a3c3af0cdbffb99e/module/src/customize.sh#L102-L114
+# Author: PerformanC
+# License: GPLv3
+
+cp "$MODPATH"/hmaoss.sh /data/adb/post-fs-data.d/hmaoss.sh
+
+mkdir -p /data/adb/post-mount.d
+cp "/data/adb/post-fs-data.d/hmaoss.sh" "/data/adb/post-mount.d/hmaoss.sh"
+
+cp "$MODPATH/module.prop" "$MODPATH/module.prop.bak"

--- a/zygote/src/main/assets/hmaoss.sh
+++ b/zygote/src/main/assets/hmaoss.sh
@@ -1,0 +1,17 @@
+#!/system/bin/sh
+
+# ref: https://github.com/PerformanC/ReZygisk/blob/main/module/src/rezygisk.sh
+
+set -e
+
+# INFO: This script gets moved to /data/adb/post-fs-data.d/hmaoss.sh
+
+# INFO: This script is utilized so that when HMA-OSS is disabled, it still can clean up its
+#         module.prop, making it not have traces of its old status.
+
+MODDIR=/data/adb/modules/hma_oss_zygisk
+
+# INFO: Resets HMA-OSS's module.prop to its default state which is saved upon installation.
+cp "$MODDIR/module.prop.bak" "$MODDIR/module.prop"
+
+exit 0

--- a/zygote/src/main/assets/hmaoss.sh
+++ b/zygote/src/main/assets/hmaoss.sh
@@ -1,0 +1,20 @@
+#!/system/bin/sh
+
+# this script contain code from ReZygisk
+# original code: https://github.com/PerformanC/ReZygisk/blob/main/module/src/rezygisk.sh
+# Author: PerformanC
+# License: GPLv3
+
+set -e
+
+# INFO: This script gets moved to /data/adb/post-fs-data.d/hmaoss.sh
+
+# INFO: This script is utilized so that when HMA-OSS is disabled, it still can clean up its
+#         module.prop, making it not have traces of its old status.
+
+MODDIR=/data/adb/modules/hma_oss_zygisk
+
+# INFO: Resets HMA-OSS's module.prop to its default state which is saved upon installation.
+cp "$MODDIR/module.prop.bak" "$MODDIR/module.prop"
+
+exit 0

--- a/zygote/src/main/assets/service.sh
+++ b/zygote/src/main/assets/service.sh
@@ -1,0 +1,13 @@
+#!/system/bin/sh
+
+MODDIR="${0%/*}"
+
+try=1
+while [ "$try" -le 10 ]; do
+    STATUS_FILE=$(ls -1 /data/misc/hide_my_applist_*/status.json 2>/dev/null | head -n 1)
+    [ -n "$STATUS_FILE" ] && [ -s "$STATUS_FILE" ] && break
+    sleep 1
+    try=$((try + 1))
+done
+
+sh "$MODDIR/update_desc.sh"

--- a/zygote/src/main/assets/service.sh
+++ b/zygote/src/main/assets/service.sh
@@ -1,0 +1,23 @@
+#!/system/bin/sh
+
+MODDIR=/data/adb/modules/hma_oss_zygisk
+LOG_FILE=$(ls -1 /data/misc/hide_my_applist_*/log/runtime.log 2>/dev/null | head -n 1)
+
+
+# if there's /, \ or & symbol, replace it with \/ (escape /), \\ (escape \) or \& (escape &)
+# in future, if HMA-OSS changed description that has / \ or & symbol, it will not break ig :p
+ORIG_DESC=$(grep "^description=" "$MODDIR/module.prop.bak" | cut -d= -f2-)
+ORIG_DESC_FIX=$(printf '%s\n' "$ORIG_DESC" | sed 's/[&/\]/\\&/g')
+
+
+MODE=$(grep "HMA service initialized in mode" "$LOG_FILE" | tail -1 | awk '{print $NF}')
+
+case "$MODE" in
+    1) STATUS="[✅ System service loaded]" ;;
+    2) STATUS="[⚠️ Sick mode - Disabled hooks]" ;;
+    3) STATUS="[⏳ Loading]" ;;
+    -*) STATUS="[❌ Not loaded - Unknown error]" ;;
+    *)  STATUS="[❓ Unknown]" ;;
+esac
+
+sed -i "s/^description=.*/description=$STATUS $ORIG_DESC_FIX/" "$MODDIR/module.prop"

--- a/zygote/src/main/assets/uninstall.sh
+++ b/zygote/src/main/assets/uninstall.sh
@@ -1,0 +1,9 @@
+#!/system/bin/sh
+
+rm -f /data/adb/post-fs-data.d/hmaoss.sh
+rm -f /data/adb/post-mount.d/hmaoss.sh
+
+# Only removes if dir is empty
+rmdir /data/adb/post-mount.d 2>/dev/null || true
+
+exit 0

--- a/zygote/src/main/assets/uninstall.sh
+++ b/zygote/src/main/assets/uninstall.sh
@@ -1,0 +1,17 @@
+#!/system/bin/sh
+
+# this script contain code from ReZygisk
+# original code: https://github.com/PerformanC/ReZygisk/blob/main/module/src/uninstall.sh
+# Author: PerformanC
+# License: GPLv3
+
+set -e
+
+rm -f /data/adb/post-fs-data.d/hmaoss.sh
+rm -f /data/adb/post-mount.d/hmaoss.sh
+
+# INFO: Only removes if dir is empty
+rmdir /data/adb/post-fs-data.d 2>/dev/null || true
+rmdir /data/adb/post-mount.d 2>/dev/null || true
+
+exit 0

--- a/zygote/src/main/assets/update_desc.sh
+++ b/zygote/src/main/assets/update_desc.sh
@@ -1,0 +1,26 @@
+#!/system/bin/sh
+
+# If you run this by hand, please use ./update_desc.sh or use full path
+#  instead of 'sh update_desc.sh' after cd
+MODDIR="${0%/*}"
+
+ORIG_DESC=$(grep "^description=" "$MODDIR/module.prop.bak" | cut -d= -f2-)
+ORIG_DESC_FIX=$(printf '%s\n' "$ORIG_DESC" | sed 's/[&/\]/\\&/g')
+
+STATUS_FILE=$(ls -1 /data/misc/hide_my_applist_*/status.json 2>/dev/null | head -n 1)
+
+if [ -z "$STATUS_FILE" ] || [ ! -s "$STATUS_FILE" ]; then
+    MODE=""
+else
+    MODE=$(sed -n 's/.*"workMode"[[:space:]]*:[[:space:]]*\([-0-9]*\).*/\1/p' "$STATUS_FILE")
+fi
+
+case "$MODE" in
+    1) STATUS="[✅ System service loaded]" ;;
+    2) STATUS="[⚠️ Sick mode - Disabled hooks]" ;;
+    3) STATUS="[⏳ Loading]" ;;
+    -*) STATUS="[❌ Not loaded - Unknown error]" ;;
+    *)  STATUS="[❓ Unknown]" ;;
+esac
+
+sed -i "s/^description=.*/description=$STATUS $ORIG_DESC_FIX/" "$MODDIR/module.prop"

--- a/zygote/src/main/assets/update_desc.sh
+++ b/zygote/src/main/assets/update_desc.sh
@@ -19,8 +19,9 @@ case "$MODE" in
     1) STATUS="[✅ System service loaded]" ;;
     2) STATUS="[⚠️ Sick mode - Disabled hooks]" ;;
     3) STATUS="[⏳ Loading]" ;;
+    4) STATUS="[❌ System service crashed]"  ;;
     -*) STATUS="[❌ Not loaded - Unknown error]" ;;
-    *)  STATUS="[❓ Unknown]" ;;
+    *) STATUS="[❓ Unknown]" ;;
 esac
 
 sed -i "s/^description=.*/description=$STATUS $ORIG_DESC_FIX/" "$MODDIR/module.prop"


### PR DESCRIPTION
## Overview
- Previously, `module.prop`'s description was static and  didn't reflect whether HMA-OSS's Zygisk hooks actually loaded, users had no quick way to tell if the module was working without opening the manager app. This PR shows HMA-OSS's current running status directly in module.prop description.

- Supported status: ( ✅ System service loaded / ⚠️ Sick mode / ⏳ Loading / ❌ Unknown error / ❓ Unknown )

## Implementation Details
- `40-setup-module-status.sh`: backup original `module.prop`, install `hmaoss.sh` into `post-fs-data.d` and `post-mount.d` for reset-on-boot
- `hmaoss.sh`: restores backed up `module.prop` to its clean state (based on PerformanC/ReZygisk)
- `service.sh`: waits for status file (max 10s) and trigger update_desc.sh
- `update_desc.sh`: parses the running mode and updates `module.prop` description
- `uninstall.sh`: cleans up the installed scripts
- `action.sh`: trigger update_desc.sh (still supports quick launch HMA-OSS manager as before, use am with -n flag and hardcode to launch on user 0)

## Known limitations
- **No real-time daemon:** Status only refreshes on boot or when the action button is pressed, no realtime updates after boot.
- **Status scope:** The log reflects the *daemon* initialization process, not the preset loading. Therefore, "Loaded" status means the daemon hook is successful, but it doesn't guarantee presets are fully ready yet.